### PR TITLE
(SIMP-2964) Add generic 'libkv::auth' parameter

### DIFF
--- a/lib/puppet/functions/libkv/atomic_create.rb
+++ b/lib/puppet/functions/libkv/atomic_create.rb
@@ -42,6 +42,11 @@ def atomic_create(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def atomic_create(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.atomic_create(url, params);
+        retval = libkv.atomic_create(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.atomic_create(url, params);
+      retval = libkv.atomic_create(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/atomic_delete.rb
+++ b/lib/puppet/functions/libkv/atomic_delete.rb
@@ -42,6 +42,11 @@ def atomic_delete(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def atomic_delete(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.atomic_delete(url, params);
+        retval = libkv.atomic_delete(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.atomic_delete(url, params);
+      retval = libkv.atomic_delete(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/atomic_get.rb
+++ b/lib/puppet/functions/libkv/atomic_get.rb
@@ -42,6 +42,11 @@ def atomic_get(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def atomic_get(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.atomic_get(url, params);
+        retval = libkv.atomic_get(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.atomic_get(url, params);
+      retval = libkv.atomic_get(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/atomic_list.rb
+++ b/lib/puppet/functions/libkv/atomic_list.rb
@@ -42,6 +42,11 @@ def atomic_list(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def atomic_list(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.atomic_list(url, params);
+        retval = libkv.atomic_list(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.atomic_list(url, params);
+      retval = libkv.atomic_list(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/atomic_put.rb
+++ b/lib/puppet/functions/libkv/atomic_put.rb
@@ -42,6 +42,11 @@ def atomic_put(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def atomic_put(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.atomic_put(url, params);
+        retval = libkv.atomic_put(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.atomic_put(url, params);
+      retval = libkv.atomic_put(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/delete.rb
+++ b/lib/puppet/functions/libkv/delete.rb
@@ -42,6 +42,11 @@ def delete(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def delete(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.delete(url, params);
+        retval = libkv.delete(url, auth, params);
       rescue
         retval = false
       end
     else
-      retval = libkv.delete(url, params);
+      retval = libkv.delete(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/deletetree.rb
+++ b/lib/puppet/functions/libkv/deletetree.rb
@@ -42,6 +42,11 @@ def deletetree(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def deletetree(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.deletetree(url, params);
+        retval = libkv.deletetree(url, auth, params);
       rescue
         retval = false
       end
     else
-      retval = libkv.deletetree(url, params);
+      retval = libkv.deletetree(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/empty_value.rb
+++ b/lib/puppet/functions/libkv/empty_value.rb
@@ -42,6 +42,11 @@ def empty_value(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def empty_value(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.empty_value(url, params);
+        retval = libkv.empty_value(url, auth, params);
       rescue
         retval = nil
       end
     else
-      retval = libkv.empty_value(url, params);
+      retval = libkv.empty_value(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/exists.rb
+++ b/lib/puppet/functions/libkv/exists.rb
@@ -42,6 +42,11 @@ def exists(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def exists(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.exists(url, params);
+        retval = libkv.exists(url, auth, params);
       rescue
         retval = nil
       end
     else
-      retval = libkv.exists(url, params);
+      retval = libkv.exists(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/get.rb
+++ b/lib/puppet/functions/libkv/get.rb
@@ -42,6 +42,11 @@ def get(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def get(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.get(url, params);
+        retval = libkv.get(url, auth, params);
       rescue
         retval = nil
       end
     else
-      retval = libkv.get(url, params);
+      retval = libkv.get(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/info.rb
+++ b/lib/puppet/functions/libkv/info.rb
@@ -42,6 +42,11 @@ def info(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def info(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.info(url, params);
+        retval = libkv.info(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.info(url, params);
+      retval = libkv.info(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/list.rb
+++ b/lib/puppet/functions/libkv/list.rb
@@ -42,6 +42,11 @@ def list(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def list(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.list(url, params);
+        retval = libkv.list(url, auth, params);
       rescue
         retval = {}
       end
     else
-      retval = libkv.list(url, params);
+      retval = libkv.list(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/newlock.rb
+++ b/lib/puppet/functions/libkv/newlock.rb
@@ -42,6 +42,11 @@ def newlock(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def newlock(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.newlock(url, params);
+        retval = libkv.newlock(url, auth, params);
       rescue
         retval = 
       end
     else
-      retval = libkv.newlock(url, params);
+      retval = libkv.newlock(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/provider.rb
+++ b/lib/puppet/functions/libkv/provider.rb
@@ -48,6 +48,11 @@ def provider(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -61,12 +66,12 @@ def provider(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.provider(url, params);
+        retval = libkv.provider(url, auth, params);
       rescue
         retval = ""
       end
     else
-      retval = libkv.provider(url, params);
+      retval = libkv.provider(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/put.rb
+++ b/lib/puppet/functions/libkv/put.rb
@@ -42,6 +42,13 @@ def put(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    require 'pry'
+    binding.pry
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +62,12 @@ def put(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.put(url, params);
+        retval = libkv.put(url, auth, params);
       rescue
         retval = false
       end
     else
-      retval = libkv.put(url, params);
+      retval = libkv.put(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/supports.rb
+++ b/lib/puppet/functions/libkv/supports.rb
@@ -48,6 +48,11 @@ def supports(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -61,12 +66,12 @@ def supports(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.supports(url, params);
+        retval = libkv.supports(url, auth, params);
       rescue
         retval = []
       end
     else
-      retval = libkv.supports(url, params);
+      retval = libkv.supports(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/watch.rb
+++ b/lib/puppet/functions/libkv/watch.rb
@@ -42,6 +42,11 @@ def watch(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def watch(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.watch(url, params);
+        retval = libkv.watch(url, auth, params);
       rescue
         retval = 
       end
     else
-      retval = libkv.watch(url, params);
+      retval = libkv.watch(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet/functions/libkv/watchtree.rb
+++ b/lib/puppet/functions/libkv/watchtree.rb
@@ -42,6 +42,11 @@ def watchtree(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -55,12 +60,12 @@ def watchtree(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.watchtree(url, params);
+        retval = libkv.watchtree(url, auth, params);
       rescue
         retval = 
       end
     else
-      retval = libkv.watchtree(url, params);
+      retval = libkv.watchtree(url, auth, params);
     end
     return retval;
   end

--- a/lib/puppet_x/libkv/loader.rb
+++ b/lib/puppet_x/libkv/loader.rb
@@ -33,13 +33,19 @@ c = Class.new do
       hash['provider'] = colonsplit[0].split("+")[0];
       return hash
   end
-  def method_missing(symbol, url, *args, &block)
-    if (urls[url] == nil)
+  def method_missing(symbol, url, auth, *args, &block)
+    if (auth == nil)
+      auth_hash = ""
+    else
+      auth_hash = auth.hash
+    end
+    instance = url + "@" + auth_hash.to_s
+    if (urls[instance] == nil)
       urlspec = parseurl(url)
       provider = urlspec['provider']
-      urls[url] = classes[provider].new(url)
+      urls[instance] = classes[provider].new(url, auth)
     end
-    object = urls[url];
+    object = urls[instance];
     object.send(symbol, *args, &block);
   end
 

--- a/lib/puppet_x/libkv/mock_provider.rb
+++ b/lib/puppet_x/libkv/mock_provider.rb
@@ -1,7 +1,7 @@
 # vim: set expandtab ts=2 sw=2:
 
 libkv.load("mock") do
-  def initialize(url)
+  def initialize(url, auth)
     @root = {};
     @mutex = Mutex.new();
     @sequence = 1;

--- a/scripts/template.erb
+++ b/scripts/template.erb
@@ -48,6 +48,11 @@ def <%= function %>(params)
     else
       url = call_function('lookup', 'libkv::url', { 'default_value' => 'mock://'})
     end
+    if params.key?('auth')
+      auth = params['auth']
+    else
+      auth = call_function('lookup', 'libkv::auth', { 'default_value' => nil })
+    end
     if params.key?('key')
       regex = Regexp.new('^\/[a-zA-Z0-9._\-\/]+$')
       unless (regex =~ params['key'])
@@ -61,12 +66,12 @@ def <%= function %>(params)
     end
     if (params["softfail"] == true)
       begin
-        retval = libkv.<%= function %>(url, params);
+        retval = libkv.<%= function %>(url, auth, params);
       rescue
         retval = <%= value[:softfail] %>
       end
     else
-      retval = libkv.<%= function %>(url, params);
+      retval = libkv.<%= function %>(url, auth, params);
     end
     return retval;
   end


### PR DESCRIPTION
* Add an opaque 'libkv::auth' parameter, which is a provider-specific
  hash containing the information necessary to authenticate.
* Create libkv instances based on the auth hash, so if two auth hashes
  are used there is no potential for leakage
* Implement basic authentication tokens for the consul provider