### PR TITLE
(SIMP-3102) Flesh out spec tests

### DIFF
--- a/lib/puppet_x/libkv/consul_provider.rb
+++ b/lib/puppet_x/libkv/consul_provider.rb
@@ -34,7 +34,7 @@ libkv.load("consul") do
       request = Net::HTTP::Delete.new(params[:path])
     when 'PUT'
       request = Net::HTTP::Put.new(params[:path])
-      request.body = params[:body]
+      request.body = params[:body].to_s
     end
     if (params.key?("headers"))
       params["headers"].each do |key, value|

--- a/lib/puppet_x/libkv/mock_provider.rb
+++ b/lib/puppet_x/libkv/mock_provider.rb
@@ -8,6 +8,9 @@ libkv.load("mock") do
   end
   def get(params)
     retval = {}
+    if (params.key?('key') == false)
+        raise "key must be specified"
+    end
     key = params['key'];
     value = @root[key];
     if value.class == Hash
@@ -53,7 +56,7 @@ libkv.load("mock") do
       @root[key] = {
         'sequence' => @sequence,
         'key' => key,
-        'value' => value,
+        'value' => value.to_s,
       }
     end
     retval["result"] = true
@@ -78,7 +81,7 @@ libkv.load("mock") do
         @root[key] = {
           'sequence' => @sequence,
           'key' => key,
-          'value' => value,
+          'value' => value.to_s,
         }
         retval["result"] = true
       else
@@ -106,7 +109,7 @@ libkv.load("mock") do
         retval["result"] = @root[key] = {
           'sequence' => @sequence,
           'key' => key,
-          'value' => value,
+          'value' => value.to_s,
         }
       else
         throw Exception

--- a/spec/functions/libkv_atomic_get_spec.rb
+++ b/spec/functions/libkv_atomic_get_spec.rb
@@ -84,6 +84,35 @@ describe 'libkv::atomic_get' do
           expect(result["value"]).to eql(nil)
         end
       end
+      datatype_testspec.each do |hash|
+        it "should return an object of type #{hash[:class]} for /atomic_get/#{hash[:key]}" do
+          params = {
+             'key' => "/atomic_get/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/atomic_get/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"].class).to eql(hash[:class])
+        end
+        it "should return '#{hash[:value]}' for /atomic_get/#{hash[:key]}" do
+          params = {
+             'key' => "/atomic_get/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/atomic_get/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]).to eql(hash[:retval])
+        end
+      end
+
     end
   end
 end

--- a/spec/functions/libkv_atomic_put_spec.rb
+++ b/spec/functions/libkv_atomic_put_spec.rb
@@ -67,6 +67,38 @@ describe 'libkv::atomic_put' do
           expect(result).to eql(nil)
         end
       end
+      datatype_testspec.each do |hash|
+        it "should return an object of type #{hash[:class]} for /atomic_put/#{hash[:key]}" do
+          params = {
+             'key' => "/atomic_put/" + hash[:key],
+          }.merge(shared_params)
+          original = call_function("libkv::atomic_get", params)
+
+          params = {
+             'key' => "/atomic_put/" + hash[:key],
+             'value' => hash[:value],
+             'previous' => original,
+          }.merge(shared_params)
+          subject.execute(params)
+          result = call_function("libkv::atomic_get", params)
+          expect(result["value"].class).to eql(hash[:class])
+        end
+        it "should return '#{hash[:value]}' for /atomic_put/#{hash[:key]}" do
+          params = {
+             'key' => "/atomic_put/" + hash[:key],
+          }.merge(shared_params)
+          original = call_function("libkv::atomic_get", params)
+
+          params = {
+             'key' => "/atomic_put/" + hash[:key],
+             'value' => hash[:value],
+             'previous' => original,
+          }.merge(shared_params)
+          subject.execute(params)
+          result = call_function("libkv::atomic_get", params)
+          expect(result["value"]).to eql(hash[:retval])
+        end
+      end
     end
   end
 end

--- a/spec/functions/libkv_get_spec.rb
+++ b/spec/functions/libkv_get_spec.rb
@@ -4,5 +4,63 @@ require 'spec_helper'
 require 'pry'
 
 valid_characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/_-+'
-invalid_characters = ";':,./<>?[]\{}|=`~!@#$%^&*()\""
+invalid_characters = ";':,./<>?[]\{}|=`~!@\#$%^&*()\""
 
+describe 'libkv::get' do
+  it 'should throw an exception with empty parameters' do
+    is_expected.to run.with_params({}).and_raise_error(Exception);
+  end
+  providers.each do |providerinfo|
+    provider = providerinfo["name"]
+    url = providerinfo["url"]
+    shared_params = {
+      "url" => url
+    }
+    context "when provider = #{provider}" do
+      it 'should throw an exception when "key" is missing' do
+        is_expected.to run.with_params(shared_params).and_raise_error(Exception);
+      end
+      it "should return nil if the key doesn't exist" do
+        params = {
+           'key' => '/puppet/get/testx',
+        }.merge(shared_params)
+        result = subject.execute(params)
+        expect(result).to eql(nil)
+      end
+
+      datatype_testspec.each do |hash|
+        it "should return an object of type #{hash[:class]} for /get/#{hash[:key]}" do
+          params = {
+             'key' => "/get/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/get/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result.class).to eql(hash[:class])
+        end
+        it "should return '#{hash[:value]}' for /get/#{hash[:key]}" do
+          params = {
+             'key' => "/get/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/get/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result).to eql(hash[:retval])
+        end
+      end
+
+        # subject.execute(params)
+        # result = call_function("libkv::get", shared_params.merge({"key" => "/test2"}))
+        # expect(result).to eql("value2")
+
+    end
+  end
+end

--- a/spec/functions/libkv_put_spec.rb
+++ b/spec/functions/libkv_put_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'pry'
 
 valid_characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/_-+'
-invalid_characters = ";':,./<>?[]\{}|=`~!@#$%^&*()\""
+invalid_characters = ";':,./<>?[]\{}|=`~!@\#$%^&*()\""
 
 describe 'libkv::put' do
   it 'should throw an exception with empty parameters' do
@@ -31,16 +31,34 @@ describe 'libkv::put' do
         result = subject.execute(params)
         expect(result.class).to eql(TrueClass)
       end
-      it 'should set the key "test2" to the value of value and libkv::get should return value' do
-        params = {
-          'key' => '/test2',
-          'value' => 'value2',
-        }.merge(shared_params)
-        subject.execute(params)
-        result = call_function("libkv::get", shared_params.merge({"key" => "/test2"}))
-        expect(result).to eql("value2")
+      datatype_testspec.each do |hash|
+        it "should create an object of type #{hash[:class]} for /put/#{hash[:key]}" do
+          params = {
+             'key' => "/put/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          subject.execute(params)
+
+          params = {
+             'key' => "/put/" + hash[:key],
+          }.merge(shared_params)
+          result = call_function("libkv::get", params)
+          expect(result.class).to eql(hash[:class])
+        end
+        it "should create the value '#{hash[:value]}' for /put/#{hash[:key]}" do
+          params = {
+             'key' => "/put/" + hash[:key],
+             'value' => hash[:value],
+          }.merge(shared_params)
+          subject.execute(params)
+
+          params = {
+             'key' => "/put/" + hash[:key],
+          }.merge(shared_params)
+          result = call_function("libkv::get", params)
+          expect(result).to eql(hash[:retval])
+        end
       end
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,7 @@ RSpec.configure do |c|
     elsif defined?(class_name)
       set_hieradata(class_name.gsub(':','_'))
     end
+    `curl -sX DELETE http://172.17.0.1:8500/v1/kv/puppet?recurse`
   end
 
   c.after(:each) do
@@ -153,6 +154,52 @@ Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
   rescue
     fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
   end
+end
+def datatype_testspec
+  [
+          # Test String
+         {
+           :key => "test_string",
+           :value => "test1",
+           :retval => "test1",
+           :class => String,
+         },
+          # Test Boolean
+         {
+           :key => "test_boolean",
+           :value => true,
+           :retval => "true",
+           :class => String,
+         },
+          # Test Number
+         {
+           :key => "test_number",
+           :value => 255,
+           :retval => '255',
+           :class => String,
+         },
+          # Test Float
+         {
+           :key => "test_float",
+           :value => 2.38490,
+           :retval => '2.3849',
+           :class => String,
+         },
+          # Test Array
+         {
+           :key => "test_array",
+           :value => [ "test3", "test4"],
+           :retval => '["test3", "test4"]',
+           :class => String,
+         },
+          # Test Hash
+         {
+           :key => "test_hash",
+           :value => { "key" => "test", "value" => "test2" },
+           :retval => '{"key"=>"test", "value"=>"test2"}',
+           :class => String,
+         },
+      ]
 end
 def providers()
 [


### PR DESCRIPTION
Add some more comprehensive spec tests, to match the expected behavior
when serialize = false, which is that libkv only deals with strings

SIMP-3102 #close