### PR TITLE
(SIMP-3109) Create a <key>.meta key to store type

### DIFF
--- a/lib/puppet_x/libkv/mock_provider.rb
+++ b/lib/puppet_x/libkv/mock_provider.rb
@@ -194,7 +194,7 @@ libkv.load("mock") do
   def list(params)
     retval = {}
     unless(params.key?('key'))
-      throw Exception
+      raise "'key' must be specified"
     end
     key = params['key']
     hash = @root.select do |k, v|
@@ -219,14 +219,24 @@ libkv.load("mock") do
   end
   def atomic_list(params)
     retval = {}
+    unless(params.key?('key'))
+      raise "'key' must be specified"
+    end
     key = params['key']
     hash = @root.select do |k, v|
       if (k =~ Regexp.new(key + '/'))
-        retval["result"] = true
+        true
       else
-        retval["result"] = false
+        false
       end
     end
+    nlist = {}
+    hash.each do |k, v|
+      reg = Regexp.new("^" + key + "/")
+      rkey = k.gsub(reg,"")
+      nlist[rkey] = v
+    end
+    retval["result"] = nlist
     if (params['debug'] == true)
       retval
     else

--- a/spec/functions/libkv_atomic_get_spec.rb
+++ b/spec/functions/libkv_atomic_get_spec.rb
@@ -89,7 +89,7 @@ describe 'libkv::atomic_get' do
         end
       end
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:class]} for /atomic_get/#{hash[:key]}" do
+        it "should return an object of type #{hash[:nonserial_class]} for /atomic_get/#{hash[:key]}" do
           params = {
              'key' => "/atomic_get/" + hash[:key],
              'value' => hash[:value],
@@ -100,7 +100,7 @@ describe 'libkv::atomic_get' do
              'key' => "/atomic_get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result["value"].class).to eql(hash[:class])
+          expect(result["value"].class).to eql(hash[:nonserial_class])
         end
         it "should return '#{hash[:value]}' for /atomic_get/#{hash[:key]}" do
           params = {

--- a/spec/functions/libkv_atomic_list_spec.rb
+++ b/spec/functions/libkv_atomic_list_spec.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby -S rspec
+# vim: set expandtab ts=2 sw=2:
+require 'spec_helper'
+require 'pry'
+
+valid_characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/_-+'
+invalid_characters = ";':,./<>?[]\{}|=`~!@#$%^&*()\""
+
+describe 'libkv::atomic_list' do
+  it 'should throw an exception with empty parameters' do
+    is_expected.to run.with_params({}).and_raise_error(Exception);
+  end
+  providers.each do |providerinfo|
+    provider = providerinfo["name"]
+    url = providerinfo["url"]
+    auth = providerinfo["auth"]
+    shared_params = {
+      "url" => url,
+      "auth" => auth,
+    }
+    context "when provider = #{provider}" do
+      context "when the key doesn't exist" do
+        it 'should return a hash' do
+          params = {
+            'key' => '/test9'
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result.class).to eql(Hash)
+        end
+        it 'should return an empty hash' do
+          params = {
+            'key' => '/test9'
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result).to eql({})
+        end
+      end
+      context "and when the key exists" do
+        def set_value(shared)
+          call_function("libkv::put", shared.merge({"value" => "value3"}))
+        end
+        it 'should return a hash' do
+          params = {
+            'key' => '/test10'
+          }.merge(shared_params)
+          set_value(params.merge({'key' => '/test10/test1', 'value' => 'value10'}))
+          set_value(params.merge({'key' => '/test10/test2', 'value' => 'value10'}))
+          result = subject.execute(params)
+          expect(result.class).to eql(Hash)
+        end
+        it 'should return a hash of strings' do
+          params = {
+            'key' => '/test10'
+          }.merge(shared_params)
+          set_value(params.merge({'key' => '/test10/test1', 'value' => 'value10'}))
+          set_value(params.merge({'key' => '/test10/test2', 'value' => 'value10'}))
+          result = subject.execute(params)
+          found_non_string = false
+          result.keys.each do |key|
+            if (key.class != String)
+              found_non_string = true
+            end
+          end
+          expect(found_non_string).to eql(false)
+        end
+        it 'when passed "fruits" it should return "apple" and "banana"' do
+          params = {
+            'key' => '/test11/fruits'
+          }.merge(shared_params)
+
+          set_value(params.merge({'key' => '/test11/fruits/apple', 'value' => 'value11'}))
+          set_value(params.merge({'key' => '/test11/fruits/banana', 'value' => 'value11'}))
+          set_value(params.merge({'key' => '/test11/meats/beef', 'value' => 'value11'}))
+          set_value(params.merge({'key' => '/test11/meats/pork', 'value' => 'value11'}))
+          result = subject.execute(params);
+          contains = result.key?("apple") and result.key?("banana");
+          expect(contains).to eql(true)
+        end
+        it 'when passed "meats" it should return "beef" and "pork"' do
+          params = {
+            'key' => '/test12/meats'
+          }.merge(shared_params)
+
+          set_value(params.merge({'key' => '/test12/fruits/apple', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test12/fruits/banana', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test12/meats/beef', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test12/meats/pork', 'value' => 'value12'}))
+
+          result = subject.execute(params);
+          contains = result.key?("beef") and result.key?("pork");
+          expect(contains).to eql(true)
+        end
+        it 'when passed "/test/list/fire" it should return "fox" and "starter" and not "/test/list/fire2/big" or "/test/list/fire2/water"' do
+          params = {
+            'key' => '/test/list/fire'
+          }.merge(shared_params)
+
+          set_value(params.merge({'key' => '/test/list/fire/fox', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test/list/fire/starter', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test/list/fire2/water', 'value' => 'value12'}))
+          set_value(params.merge({'key' => '/test/list/fire2/big', 'value' => 'value12'}))
+
+          result = subject.execute(params);
+          contains = result.key?("fox") and result.key?("starter");
+          size = result.size;
+          expect(contains).to eql(true)
+          expect(size).to eql(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/functions/libkv_get_spec.rb
+++ b/spec/functions/libkv_get_spec.rb
@@ -33,7 +33,7 @@ describe 'libkv::get' do
       end
 
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:class]} for /get/#{hash[:key]}" do
+        it "should return an object of type #{hash[:nonserial_class]} for /get/#{hash[:key]}" do
           params = {
              'key' => "/get/" + hash[:key],
              'value' => hash[:value],
@@ -44,7 +44,7 @@ describe 'libkv::get' do
              'key' => "/get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result.class).to eql(hash[:class])
+          expect(result.class).to eql(hash[:nonserial_class])
         end
         it "should return '#{hash[:value]}' for /get/#{hash[:key]}" do
           params = {

--- a/spec/functions/libkv_put_spec.rb
+++ b/spec/functions/libkv_put_spec.rb
@@ -36,7 +36,7 @@ describe 'libkv::put' do
         expect(result.class).to eql(TrueClass)
       end
       datatype_testspec.each do |hash|
-        it "should create an object of type #{hash[:class]} for /put/#{hash[:key]}" do
+        it "should create an object of type #{hash[:nonserial_class]} for /put/#{hash[:key]}" do
           params = {
              'key' => "/put/" + hash[:key],
              'value' => hash[:value],
@@ -47,7 +47,7 @@ describe 'libkv::put' do
              'key' => "/put/" + hash[:key],
           }.merge(shared_params)
           result = call_function("libkv::get", params)
-          expect(result.class).to eql(hash[:class])
+          expect(result.class).to eql(hash[:nonserial_class])
         end
         it "should create the value '#{hash[:value]}' for /put/#{hash[:key]}" do
           params = {
@@ -61,6 +61,34 @@ describe 'libkv::put' do
           }.merge(shared_params)
           result = call_function("libkv::get", params)
           expect(result).to eql(hash[:retval])
+        end
+        unless (hash[:class] == "String")
+          it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:class]}" do
+            params = {
+             'key' => "/put/" + hash[:key],
+             'value' => hash[:value],
+            }.merge(shared_params)
+            subject.execute(params)
+
+            params = {
+               'key' => "/put/" + hash[:key] + ".meta",
+            }.merge(shared_params)
+            result = call_function("libkv::get", params)
+            expect(result).to_not eql(nil)
+            expect(result.class).to eql(String)
+            attempt_to_parse = nil
+            res = nil
+            begin
+              res = JSON.parse(result)
+              attempt_to_parse = true
+            rescue
+              attempt_to_parse = false
+            end
+            expect(attempt_to_parse).to eql(true)
+            expect(res.class).to eql(Hash)
+            expect(res["type"]).to eql(hash[:class].to_s)
+          end
+
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ end
 #
 # Example:
 #
-# describe 'some::class' do
+# describe 'some::nonserial_class' do
 #   context 'with version 10' do
 #     let(:hieradata){ "#{class_name}_v10" }
 #     ...
@@ -160,45 +160,51 @@ def datatype_testspec
   [
           # Test String
          {
-           :key => "test_string",
+          :key => "test_string",
            :value => "test1",
            :retval => "test1",
-           :class => String,
+           :nonserial_class => String,
+	   :class => "String",
          },
           # Test Boolean
          {
            :key => "test_boolean",
            :value => true,
            :retval => "true",
-           :class => String,
+           :nonserial_class => String,
+	   :class => "Boolean",
          },
           # Test Number
          {
            :key => "test_number",
            :value => 255,
            :retval => '255',
-           :class => String,
+           :nonserial_class => String,
+	   :class => "Integer",
          },
           # Test Float
          {
            :key => "test_float",
            :value => 2.38490,
            :retval => '2.3849',
-           :class => String,
+           :nonserial_class => String,
+	   :class => "Float",
          },
           # Test Array
          {
            :key => "test_array",
            :value => [ "test3", "test4"],
            :retval => '["test3", "test4"]',
-           :class => String,
+           :nonserial_class => String,
+	   :class => "Array",
          },
           # Test Hash
          {
            :key => "test_hash",
            :value => { "key" => "test", "value" => "test2" },
            :retval => '{"key"=>"test", "value"=>"test2"}',
-           :class => String,
+           :nonserial_class => String,
+	   :class => "Hash",
          },
       ]
 end


### PR DESCRIPTION
* Create a <key>.meta key to store metadata for each put.
  This will be necessary to properly deserialize types.
* Add spec tests for atomic_list and make sure that list/
  atomic_list filter out .meta keys.
* Fix bug in consul's atomic_list implementation

SIMP-3109 #close