### PR TITLE
(SIMP-3110) Use <key>.meta to convert a value to the correct type

### DIFF
--- a/spec/functions/libkv_atomic_get_spec.rb
+++ b/spec/functions/libkv_atomic_get_spec.rb
@@ -89,7 +89,17 @@ describe 'libkv::atomic_get' do
         end
       end
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:nonserial_class]} for /atomic_get/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /atomic_get/#{hash[:key]}" do
           params = {
              'key' => "/atomic_get/" + hash[:key],
              'value' => hash[:value],
@@ -100,7 +110,7 @@ describe 'libkv::atomic_get' do
              'key' => "/atomic_get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result["value"].class).to eql(hash[:nonserial_class])
+          expect(result["value"].class.to_s).to eql(klass)
         end
         it "should return '#{hash[:value]}' for /atomic_get/#{hash[:key]}" do
           params = {
@@ -113,7 +123,7 @@ describe 'libkv::atomic_get' do
              'key' => "/atomic_get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result["value"]).to eql(hash[:retval])
+          expect(result["value"]).to eql(expected_retval)
         end
       end
 

--- a/spec/functions/libkv_atomic_list_spec.rb
+++ b/spec/functions/libkv_atomic_list_spec.rb
@@ -14,9 +14,11 @@ describe 'libkv::atomic_list' do
     provider = providerinfo["name"]
     url = providerinfo["url"]
     auth = providerinfo["auth"]
+    serialize = providerinfo["serialize"]
     shared_params = {
       "url" => url,
       "auth" => auth,
+      "serialize" => serialize,
     }
     context "when provider = #{provider}" do
       context "when the key doesn't exist" do
@@ -105,6 +107,44 @@ describe 'libkv::atomic_list' do
           size = result.size;
           expect(contains).to eql(true)
           expect(size).to eql(2)
+        end
+      end
+      datatype_testspec.each do |hash|
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]["value"].class.to_s).to eql(klass)
+        end
+        it "should return '#{hash[:value]}' for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]["value"]).to eql(expected_retval)
         end
       end
     end

--- a/spec/functions/libkv_get_spec.rb
+++ b/spec/functions/libkv_get_spec.rb
@@ -33,7 +33,17 @@ describe 'libkv::get' do
       end
 
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:nonserial_class]} for /get/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /get/#{hash[:key]}" do
           params = {
              'key' => "/get/" + hash[:key],
              'value' => hash[:value],
@@ -44,7 +54,7 @@ describe 'libkv::get' do
              'key' => "/get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result.class).to eql(hash[:nonserial_class])
+          expect(result.class.to_s).to eql(klass)
         end
         it "should return '#{hash[:value]}' for /get/#{hash[:key]}" do
           params = {
@@ -57,7 +67,7 @@ describe 'libkv::get' do
              'key' => "/get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result).to eql(hash[:retval])
+          expect(result).to eql(expected_retval)
         end
       end
 

--- a/spec/functions/libkv_list_spec.rb
+++ b/spec/functions/libkv_list_spec.rb
@@ -14,9 +14,11 @@ describe 'libkv::list' do
     provider = providerinfo["name"]
     url = providerinfo["url"]
     auth = providerinfo["auth"]
+    serialize = providerinfo["serialize"]
     shared_params = {
       "url" => url,
       "auth" => auth,
+      "serialize" => serialize,
     }
     context "when provider = #{provider}" do
       context "when the key doesn't exist" do
@@ -106,6 +108,44 @@ describe 'libkv::list' do
           size = result.size;
           expect(contains).to eql(true)
           expect(size).to eql(2)
+        end
+      end
+      datatype_testspec.each do |hash|
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"].class.to_s).to eql(klass)
+        end
+        it "should return '#{hash[:value]}' for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]).to eql(expected_retval)
         end
       end
     end

--- a/spec/functions/libkv_put_spec.rb
+++ b/spec/functions/libkv_put_spec.rb
@@ -20,6 +20,7 @@ describe 'libkv::put' do
       "mode" => providerinfo["mode"],
       "auth" => auth,
     }
+
     context "when provider = #{provider}" do
       it 'should throw an exception when "key" is missing' do
         is_expected.to run.with_params(shared_params).and_raise_error(Exception)
@@ -36,7 +37,17 @@ describe 'libkv::put' do
         expect(result.class).to eql(TrueClass)
       end
       datatype_testspec.each do |hash|
-        it "should create an object of type #{hash[:nonserial_class]} for /put/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should create an object of type #{klass} for /put/#{hash[:key]}" do
           params = {
              'key' => "/put/" + hash[:key],
              'value' => hash[:value],
@@ -47,7 +58,7 @@ describe 'libkv::put' do
              'key' => "/put/" + hash[:key],
           }.merge(shared_params)
           result = call_function("libkv::get", params)
-          expect(result.class).to eql(hash[:nonserial_class])
+          expect(result.class.to_s).to eql(klass)
         end
         it "should create the value '#{hash[:value]}' for /put/#{hash[:key]}" do
           params = {
@@ -60,35 +71,36 @@ describe 'libkv::put' do
              'key' => "/put/" + hash[:key],
           }.merge(shared_params)
           result = call_function("libkv::get", params)
-          expect(result).to eql(hash[:retval])
+          expect(result).to eql(expected_retval)
         end
         unless (hash[:class] == "String")
-          it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:class]}" do
-            params = {
-             'key' => "/put/" + hash[:key],
-             'value' => hash[:value],
-            }.merge(shared_params)
-            subject.execute(params)
+          if (providerinfo["serialize"] == true)
+            it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:puppet_type]}" do
+              params = {
+               'key' => "/put/" + hash[:key],
+                'value' => hash[:value],
+              }.merge(shared_params)
+              subject.execute(params)
 
-            params = {
-               'key' => "/put/" + hash[:key] + ".meta",
-            }.merge(shared_params)
-            result = call_function("libkv::get", params)
-            expect(result).to_not eql(nil)
-            expect(result.class).to eql(String)
-            attempt_to_parse = nil
-            res = nil
-            begin
-              res = JSON.parse(result)
-              attempt_to_parse = true
-            rescue
-              attempt_to_parse = false
+              params = {
+                 'key' => "/put/" + hash[:key] + ".meta",
+              }.merge(shared_params)
+              result = call_function("libkv::get", params)
+              expect(result).to_not eql(nil)
+              expect(result.class).to eql(String)
+              attempt_to_parse = nil
+              res = nil
+              begin
+                res = JSON.parse(result)
+                attempt_to_parse = true
+              rescue
+                attempt_to_parse = false
+              end
+              expect(attempt_to_parse).to eql(true)
+              expect(res.class).to eql(Hash)
+              expect(res["type"]).to eql(hash[:puppet_type].to_s)
             end
-            expect(attempt_to_parse).to eql(true)
-            expect(res.class).to eql(Hash)
-            expect(res["type"]).to eql(hash[:class].to_s)
           end
-
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -162,49 +162,55 @@ def datatype_testspec
          {
           :key => "test_string",
            :value => "test1",
-           :retval => "test1",
-           :nonserial_class => String,
+           :nonserial_retval => "test1",
+           :nonserial_class => "String",
 	   :class => "String",
+	   :puppet_type => "String",
          },
           # Test Boolean
          {
            :key => "test_boolean",
            :value => true,
-           :retval => "true",
-           :nonserial_class => String,
-	   :class => "Boolean",
+           :nonserial_retval => "true",
+           :nonserial_class => "String",
+	   :class => "TrueClass",
+	   :puppet_type => "Boolean",
          },
           # Test Number
          {
            :key => "test_number",
            :value => 255,
-           :retval => '255',
-           :nonserial_class => String,
-	   :class => "Integer",
+           :nonserial_retval => '255',
+           :nonserial_class => "String",
+	   :class => "Fixnum",
+	   :puppet_type => "Integer",
          },
           # Test Float
          {
            :key => "test_float",
            :value => 2.38490,
-           :retval => '2.3849',
-           :nonserial_class => String,
+           :nonserial_retval => '2.3849',
+           :nonserial_class => "String",
 	   :class => "Float",
+	   :puppet_type => "Float",
          },
           # Test Array
          {
            :key => "test_array",
            :value => [ "test3", "test4"],
-           :retval => '["test3", "test4"]',
-           :nonserial_class => String,
+           :nonserial_retval => '["test3", "test4"]',
+           :nonserial_class => "String",
 	   :class => "Array",
+	   :puppet_type => "Array",
          },
           # Test Hash
          {
            :key => "test_hash",
            :value => { "key" => "test", "value" => "test2" },
-           :retval => '{"key"=>"test", "value"=>"test2"}',
-           :nonserial_class => String,
+           :nonserial_retval => '{"key"=>"test", "value"=>"test2"}',
+           :nonserial_class => "String",
 	   :class => "Hash",
+	   :puppet_type => "Hash",
          },
       ]
 end
@@ -224,6 +230,7 @@ def providers()
 	  "name" => "mock with serialize true and mode is 'native'",
 	  "url" => "mock://",
           "serialize" => true,
+	  "mode" => 'native',
   },
   {
 	  "name" => "consul with serialize false and with daemon",


### PR DESCRIPTION
* When serialize is true, convert data into json on put/atomic_put
* When serialize is true, convert data from json on get/atomic_get based
on the data type in <key>.meta
* Update all spec tests to support this change
* Add a sanitize_input() function that uses symbol_table() to figure out
  required parameters, and check them for sanity. This should replace
  the provider specific error checking.

SIMP-3110 #close