### PR TITLE
(SIMP-3110) Use <key>.meta to convert a value to the correct type

### DIFF
--- a/lib/puppet_x/libkv/loader.rb
+++ b/lib/puppet_x/libkv/loader.rb
@@ -23,24 +23,119 @@ c = Class.new do
   attr_accessor :classes
   attr_accessor :urls
   attr_accessor :default_url
-  
+
   def load(name, &block)
     @classes[name] = Class.new(&block)
   end
   def parseurl(url)
-      hash = {}
-      colonsplit = url.split(":");
-      hash['provider'] = colonsplit[0].split("+")[0];
-      return hash
+    hash = {}
+    colonsplit = url.split(":");
+    hash['provider'] = colonsplit[0].split("+")[0];
+    return hash
+  end
+  def symbol_table()
+    {
+      :params => {
+        'key' => "KeySpecification",
+        'previous' => "Hash",
+        'url' => "String",
+        'auth' => "Hash",
+        'value' => "",
+      },
+      :get => {
+        'key' => "required",
+      },
+      :put => {
+        'key' => "required",
+        'value' => "required",
+      },
+      :delete => {
+        'key' => "required",
+      },
+      :exists => {
+        'key' => "required",
+      },
+      :list => {
+        'key' => "required",
+      },
+      :deletetree => {
+        'key' => "required",
+      },
+      :atomic_create => {
+        'key' => "required",
+        'value' => "required",
+      },
+      :atomic_delete => {
+        'key' => "required",
+        'previous' => "required",
+      },
+      :atomic_get => {
+        'key' => "required",
+      },
+      :atomic_put => {
+        'key' => "required",
+        'value' => "required",
+        'previous' => "required",
+      },
+      :atomic_list => {
+        'key' => "required",
+      },
+    }
+  end
+  def sanitize_input(symbol, params)
+    if (params.class.to_s != "Hash")
+      raise "parameter 0 needs to be a Hash, found #{params.class.to_s}"
+    end
+    table = symbol_table
+    if (table.key?(symbol))
+      function_parameters = table[symbol]
+      function_parameters.each do |name, status|
+        found = params.key?(name)
+        case status
+        when "required"
+          if (found == false)
+            raise "parameter: #{name} not found"
+          end
+        end
+        if (found == true)
+          definition = table[:params][name]
+          case definition
+          when ""
+            if (params[name] == nil)
+              raise "parameter #{name} should not be nil"
+            end
+          when "KeySpecification"
+            unless (params[name].class.to_s == "String")
+              raise "parameter #{name} should be String, found #{params[name].class.to_s}"
+            end
+          else
+            unless (params[name].class.to_s == definition)
+              raise "parameter #{name} should be #{definition}, found #{params[name].class.to_s}"
+            end
+          end
+        end
+      end
+    end
   end
   def method_missing(symbol, url, auth, *args, &block)
-    params = args[0]
+    sanitize_input(symbol, args[0])
+    # For safety make a new hash. This doesn't prevent side effects
+    # but reduces them somewhat
+    params = args[0].dup
+    nargs = [ params ]
+    # ddb hook for testing.
+    # if (params['dd'] == true)
+    #   binding.pry
+    # end
+
     unless (params.key?("serialize"))
-      params["serialize"] = false
+      params["serialize"] = true
     end
-    unless (params.key?("mode"))
+    serialize = params["serialize"]
+    if (params.key?("mode") == false or params["mode"] == "" or params["mode"] == nil)
       params["mode"] = 'puppet'
     end
+
     if (auth == nil)
       auth_hash = ""
     else
@@ -55,50 +150,122 @@ c = Class.new do
     object = urls[instance];
     case symbol
     when :put
-      meta = []
-      meta[0] = Hash.new(params)
-      meta[0]["key"] = "#{params['key']}.meta"
-      nvalue = {}
-      nvalue["type"] = puppetype(params["value"])
-      nvalue["format"] = "json"
-      nvalue["mode"] = "puppet"
-      meta[0]["value"] = nvalue.to_json
-      object.send(:put, *meta, &block);
+      if (serialize == true)
+        meta = get_metadata(params, object)
+        params["value"] = pack(meta, params["value"])
+      end
+      retval = object.send(symbol, *nargs, &block);
     when :atomic_put
-      meta = []
-      meta[0] = Hash.new(params)
-      meta[0]["key"] = "#{params['key']}.meta"
-      nvalue = {}
-      nvalue["type"] = puppetype(params["value"])
-      nvalue["format"] = "json"
-      nvalue["mode"] = "puppet"
-      meta[0]["value"] = nvalue.to_json
-      object.send(:put, *meta, &block);
-    end
-    retval = object.send(symbol, *args, &block);
-    case symbol
-    when :list
-	filtered_list = {}
-	retval.each do |entry, value|
-          unless (entry =~ /.*\.meta$/)
-            filtered_list[entry] = value
-          end
-	end
-        return filtered_list
-    when :atomic_list
-	filtered_list = {}
-	retval.each do |entry, value|
-          unless (entry =~ /.*\.meta$/)
-            filtered_list[entry] = value
-          end
-	end
-        return filtered_list
+      if (serialize == true)
+        meta = get_metadata(params, object)
+        params["value"] = pack(meta, params["value"])
+      end
+      retval = object.send(symbol, *nargs, &block);
     else
-       return retval
+      retval = object.send(symbol, *nargs, &block);
+    end
+
+    case symbol
+    when :get
+      if (serialize == true and params["key"] !~ /.*\.meta$/)
+        metadata = get_metadata(params, object);
+        return unpack(metadata,retval)
+      else
+        return retval
+      end
+    when :atomic_get
+      if (serialize == true and params["key"] !~ /.*\.meta$/)
+        metadata = get_metadata(params, object);
+        if (retval.key?("value"))
+          value = unpack(metadata,retval["value"])
+          retval["value"] = value
+        end
+        return retval
+      else
+        return retval
+      end
+    when :list
+      filtered_list = {}
+      retval.each do |entry, value|
+        unless (entry =~ /.*\.meta$/)
+          if (serialize == true)
+            metadata = get_metadata(params.merge({ "key" => "#{params['key']}/#{entry}" }), object)
+            filtered_list[entry] = unpack(metadata, value)
+          else
+            filtered_list[entry] = value
+          end
+        end
+      end
+      return filtered_list
+    when :atomic_list
+      filtered_list = {}
+      retval.each do |entry, value|
+        unless (entry =~ /.*\.meta$/)
+          if (serialize == true)
+            metadata = get_metadata(params.merge({ "key" => "#{params['key']}/#{entry}" }), object)
+            value["value"] = unpack(metadata, value["value"])
+            filtered_list[entry] = value
+          else
+            filtered_list[entry] = value
+          end
+        end
+      end
+      return filtered_list
+    else
+      return retval
     end
   end
+  def get_metadata(params, object)
+    meta = []
+    meta[0] = params.dup
+    meta[0]["key"] = "#{params['key']}.meta"
+    # XXX FIXME: Make this atomic
+    if (object.send(:exists, *meta))
+      metadata = object.send(:get, *meta)
+      retval = JSON.parse(metadata)
+    else
+      retval = {}
+      retval["format"] = "json"
+      retval["mode"] = params["mode"]
+      if (params.key?("value"))
+        retval["type"] = puppetype(params["value"])
+        meta[0]["value"] = retval.to_json
+        object.send(:put, *meta);
+      end
+    end
+    return retval
+  end
+  def pack(meta, value)
+    unless (meta["type"] == "String")
+      # JSON objects need to be real objects, or else the parser blows up. So wrap in a hash
+      encapsulation = { "value" => value }
+      encapsulation.to_json
+    else
+      value
+    end
+  end
+  def unpack(meta, value)
+    retval = value
+    case meta["mode"]
+    when "puppet"
+      unless (meta["type"] == "String")
+        case meta["format"]
+        when "json"
+          unless value == nil
+            object = JSON.parse(value)
+            retval = object["value"]
+          end
+        else
+          raise "Unknown format: #{meta["format"]}"
+        end
+      end
+    else
+      raise "Unknown mode: #{meta["mode"]}"
+    end
+    return retval
+  end
   def puppetype(klass)
-    retval = nil
+    retval = klass.class.to_s
     case klass.class.to_s
     when "Fixnum"
       retval = "Integer"

--- a/spec/functions/libkv_atomic_get_spec.rb
+++ b/spec/functions/libkv_atomic_get_spec.rb
@@ -88,7 +88,17 @@ describe 'libkv::atomic_get' do
         end
       end
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:nonserial_class]} for /atomic_get/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /atomic_get/#{hash[:key]}" do
           params = {
              'key' => "/atomic_get/" + hash[:key],
              'value' => hash[:value],
@@ -99,7 +109,7 @@ describe 'libkv::atomic_get' do
              'key' => "/atomic_get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result["value"].class).to eql(hash[:nonserial_class])
+          expect(result["value"].class.to_s).to eql(klass)
         end
         it "should return '#{hash[:value]}' for /atomic_get/#{hash[:key]}" do
           params = {
@@ -112,7 +122,7 @@ describe 'libkv::atomic_get' do
              'key' => "/atomic_get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result["value"]).to eql(hash[:retval])
+          expect(result["value"]).to eql(expected_retval)
         end
       end
 

--- a/spec/functions/libkv_atomic_list_spec.rb
+++ b/spec/functions/libkv_atomic_list_spec.rb
@@ -13,9 +13,11 @@ describe 'libkv::atomic_list' do
     provider = providerinfo["name"]
     url = providerinfo["url"]
     auth = providerinfo["auth"]
+    serialize = providerinfo["serialize"]
     shared_params = {
       "url" => url,
       "auth" => auth,
+      "serialize" => serialize,
     }
     context "when provider = #{provider}" do
       context "when the key doesn't exist" do
@@ -104,6 +106,44 @@ describe 'libkv::atomic_list' do
           size = result.size;
           expect(contains).to eql(true)
           expect(size).to eql(2)
+        end
+      end
+      datatype_testspec.each do |hash|
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]["value"].class.to_s).to eql(klass)
+        end
+        it "should return '#{hash[:value]}' for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]["value"]).to eql(expected_retval)
         end
       end
     end

--- a/spec/functions/libkv_atomic_put_spec.rb
+++ b/spec/functions/libkv_atomic_put_spec.rb
@@ -55,8 +55,8 @@ describe 'libkv::atomic_put' do
             'key' => '/test/atomic_put/test4'
           }.merge(shared_params)
           call_function("libkv::put", params.merge({'key' => '/test/atomic_put/test5', 'value' => 'value5'}))
-          random = call_function("libkv::get", params.merge({'key' => '/test/atomic_put/test5'}))
-          result = subject.execute(params.merge({'previous' => random, 'value' => 'value4'}))
+          random = call_function("libkv::atomic_get", params.merge({'key' => '/test/atomic_put/test5'}))
+          result = subject.execute(params.merge( { 'previous' => random, 'value' => 'value4'}))
           expect(result).to eql(false)
         end
         it 'should not set the key to value' do
@@ -64,14 +64,24 @@ describe 'libkv::atomic_put' do
             'key' => '/test/atomic_put/test6'
           }.merge(shared_params)
           call_function("libkv::put", params.merge({'key' => '/test/atomic_put/test5', 'value' => 'value5'}))
-          random = call_function("libkv::get", params.merge({'key' => '/test/atomic_put/test5'}))
+          random = call_function("libkv::atomic_get", params.merge({'key' => '/test/atomic_put/test5'}))
           subject.execute(params.merge({'previous' => random, 'value' => 'value6'}))
           result = call_function("libkv::get", params)
           expect(result).to eql(nil)
         end
       end
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:nonserial_class]} for /atomic_put/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /atomic_put/#{hash[:key]}" do
           params = {
              'key' => "/atomic_put/" + hash[:key],
           }.merge(shared_params)
@@ -84,9 +94,9 @@ describe 'libkv::atomic_put' do
           }.merge(shared_params)
           subject.execute(params)
           result = call_function("libkv::atomic_get", params)
-          expect(result["value"].class).to eql(hash[:nonserial_class])
+          expect(result["value"].class.to_s).to eql(klass)
         end
-        it "should return '#{hash[:value]}' for /atomic_put/#{hash[:key]}" do
+        it "should return '#{expected_retval}' for /atomic_put/#{hash[:key]}" do
           params = {
              'key' => "/atomic_put/" + hash[:key],
           }.merge(shared_params)
@@ -99,41 +109,42 @@ describe 'libkv::atomic_put' do
           }.merge(shared_params)
           subject.execute(params)
           result = call_function("libkv::atomic_get", params)
-          expect(result["value"]).to eql(hash[:retval])
+          expect(result["value"]).to eql(expected_retval)
         end
         unless (hash[:class] == "String")
-          it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:class]}" do
-            params = {
-              'key' => "/atomic_put/" + hash[:key],
-            }.merge(shared_params)
-            original = call_function("libkv::atomic_get", params)
+          if (providerinfo["serialize"] == true)
+            it "should create the key '/atomic_put/#{hash[:key]}.meta' and contain a type = #{hash[:puppet_type]}" do
+              params = {
+                'key' => "/atomic_put/" + hash[:key],
+              }.merge(shared_params)
+              original = call_function("libkv::atomic_get", params)
 
-            params = {
-             'key' => "/atomic_put/" + hash[:key],
-             'value' => hash[:value],
-             'previous' => original,
-            }.merge(shared_params)
-            subject.execute(params)
+              params = {
+               'key' => "/atomic_put/" + hash[:key],
+               'value' => hash[:value],
+               'previous' => original,
+              }.merge(shared_params)
+              subject.execute(params)
 
-            params = {
+              params = {
                'key' => "/atomic_put/" + hash[:key] + ".meta",
-            }.merge(shared_params)
-            result = call_function("libkv::get", params)
-            expect(result).to_not eql(nil)
-            expect(result.class).to eql(String)
-            attempt_to_parse = nil
-            res = nil
-            begin
-              res = JSON.parse(result)
-              attempt_to_parse = true
-            rescue
-              attempt_to_parse = false
+              }.merge(shared_params)
+              result = call_function("libkv::get", params)
+              expect(result).to_not eql(nil)
+              expect(result.class).to eql(String)
+              attempt_to_parse = nil
+              res = nil
+              begin
+                res = JSON.parse(result)
+                attempt_to_parse = true
+              rescue
+                attempt_to_parse = false
+              end
+              expect(attempt_to_parse).to eql(true)
+              expect(res.class).to eql(Hash)
+              expect(res["type"]).to eql(hash[:puppet_type].to_s)
             end
-            expect(attempt_to_parse).to eql(true)
-            expect(res.class).to eql(Hash)
-            expect(res["type"]).to eql(hash[:class].to_s)
           end
-
         end
       end
     end

--- a/spec/functions/libkv_get_spec.rb
+++ b/spec/functions/libkv_get_spec.rb
@@ -32,7 +32,17 @@ describe 'libkv::get' do
       end
 
       datatype_testspec.each do |hash|
-        it "should return an object of type #{hash[:nonserial_class]} for /get/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /get/#{hash[:key]}" do
           params = {
              'key' => "/get/" + hash[:key],
              'value' => hash[:value],
@@ -43,7 +53,7 @@ describe 'libkv::get' do
              'key' => "/get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result.class).to eql(hash[:nonserial_class])
+          expect(result.class.to_s).to eql(klass)
         end
         it "should return '#{hash[:value]}' for /get/#{hash[:key]}" do
           params = {
@@ -56,7 +66,7 @@ describe 'libkv::get' do
              'key' => "/get/" + hash[:key],
           }.merge(shared_params)
           result = subject.execute(params)
-          expect(result).to eql(hash[:retval])
+          expect(result).to eql(expected_retval)
         end
       end
 

--- a/spec/functions/libkv_list_spec.rb
+++ b/spec/functions/libkv_list_spec.rb
@@ -13,9 +13,11 @@ describe 'libkv::list' do
     provider = providerinfo["name"]
     url = providerinfo["url"]
     auth = providerinfo["auth"]
+    serialize = providerinfo["serialize"]
     shared_params = {
       "url" => url,
       "auth" => auth,
+      "serialize" => serialize,
     }
     context "when provider = #{provider}" do
       context "when the key doesn't exist" do
@@ -105,6 +107,44 @@ describe 'libkv::list' do
           size = result.size;
           expect(contains).to eql(true)
           expect(size).to eql(2)
+        end
+      end
+      datatype_testspec.each do |hash|
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should return an object of type #{klass} for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"].class.to_s).to eql(klass)
+        end
+        it "should return '#{hash[:value]}' for /list/#{hash[:key]}" do
+          params = {
+             'key' => "/list/" + hash[:key] + "/value",
+             'value' => hash[:value],
+          }.merge(shared_params)
+          call_function("libkv::put", params)
+
+          params = {
+             'key' => "/list/" + hash[:key],
+          }.merge(shared_params)
+          result = subject.execute(params)
+          expect(result["value"]).to eql(expected_retval)
         end
       end
     end

--- a/spec/functions/libkv_put_spec.rb
+++ b/spec/functions/libkv_put_spec.rb
@@ -19,6 +19,7 @@ describe 'libkv::put' do
       "mode" => providerinfo["mode"],
       "auth" => auth,
     }
+
     context "when provider = #{provider}" do
       it 'should throw an exception when "key" is missing' do
         is_expected.to run.with_params(shared_params).and_raise_error(Exception)
@@ -35,7 +36,17 @@ describe 'libkv::put' do
         expect(result.class).to eql(TrueClass)
       end
       datatype_testspec.each do |hash|
-        it "should create an object of type #{hash[:nonserial_class]} for /put/#{hash[:key]}" do
+       if (providerinfo["serialize"] == true)
+         klass = hash[:class]
+       else
+         klass = hash[:nonserial_class]
+       end
+       if (providerinfo["serialize"] == true)
+         expected_retval = hash[:value]
+       else
+         expected_retval = hash[:nonserial_retval]
+       end
+        it "should create an object of type #{klass} for /put/#{hash[:key]}" do
           params = {
              'key' => "/put/" + hash[:key],
              'value' => hash[:value],
@@ -46,7 +57,7 @@ describe 'libkv::put' do
              'key' => "/put/" + hash[:key],
           }.merge(shared_params)
           result = call_function("libkv::get", params)
-          expect(result.class).to eql(hash[:nonserial_class])
+          expect(result.class.to_s).to eql(klass)
         end
         it "should create the value '#{hash[:value]}' for /put/#{hash[:key]}" do
           params = {
@@ -59,35 +70,36 @@ describe 'libkv::put' do
              'key' => "/put/" + hash[:key],
           }.merge(shared_params)
           result = call_function("libkv::get", params)
-          expect(result).to eql(hash[:retval])
+          expect(result).to eql(expected_retval)
         end
         unless (hash[:class] == "String")
-          it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:class]}" do
-            params = {
-             'key' => "/put/" + hash[:key],
-             'value' => hash[:value],
-            }.merge(shared_params)
-            subject.execute(params)
+          if (providerinfo["serialize"] == true)
+            it "should create the key '/put/#{hash[:key]}.meta' and contain a type = #{hash[:puppet_type]}" do
+              params = {
+               'key' => "/put/" + hash[:key],
+                'value' => hash[:value],
+              }.merge(shared_params)
+              subject.execute(params)
 
-            params = {
-               'key' => "/put/" + hash[:key] + ".meta",
-            }.merge(shared_params)
-            result = call_function("libkv::get", params)
-            expect(result).to_not eql(nil)
-            expect(result.class).to eql(String)
-            attempt_to_parse = nil
-            res = nil
-            begin
-              res = JSON.parse(result)
-              attempt_to_parse = true
-            rescue
-              attempt_to_parse = false
+              params = {
+                 'key' => "/put/" + hash[:key] + ".meta",
+              }.merge(shared_params)
+              result = call_function("libkv::get", params)
+              expect(result).to_not eql(nil)
+              expect(result.class).to eql(String)
+              attempt_to_parse = nil
+              res = nil
+              begin
+                res = JSON.parse(result)
+                attempt_to_parse = true
+              rescue
+                attempt_to_parse = false
+              end
+              expect(attempt_to_parse).to eql(true)
+              expect(res.class).to eql(Hash)
+              expect(res["type"]).to eql(hash[:puppet_type].to_s)
             end
-            expect(attempt_to_parse).to eql(true)
-            expect(res.class).to eql(Hash)
-            expect(res["type"]).to eql(hash[:class].to_s)
           end
-
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -162,49 +162,55 @@ def datatype_testspec
          {
           :key => "test_string",
            :value => "test1",
-           :retval => "test1",
-           :nonserial_class => String,
+           :nonserial_retval => "test1",
+           :nonserial_class => "String",
 	   :class => "String",
+	   :puppet_type => "String",
          },
           # Test Boolean
          {
            :key => "test_boolean",
            :value => true,
-           :retval => "true",
-           :nonserial_class => String,
-	   :class => "Boolean",
+           :nonserial_retval => "true",
+           :nonserial_class => "String",
+	   :class => "TrueClass",
+	   :puppet_type => "Boolean",
          },
           # Test Number
          {
            :key => "test_number",
            :value => 255,
-           :retval => '255',
-           :nonserial_class => String,
-	   :class => "Integer",
+           :nonserial_retval => '255',
+           :nonserial_class => "String",
+	   :class => "Fixnum",
+	   :puppet_type => "Integer",
          },
           # Test Float
          {
            :key => "test_float",
            :value => 2.38490,
-           :retval => '2.3849',
-           :nonserial_class => String,
+           :nonserial_retval => '2.3849',
+           :nonserial_class => "String",
 	   :class => "Float",
+	   :puppet_type => "Float",
          },
           # Test Array
          {
            :key => "test_array",
            :value => [ "test3", "test4"],
-           :retval => '["test3", "test4"]',
-           :nonserial_class => String,
+           :nonserial_retval => '["test3", "test4"]',
+           :nonserial_class => "String",
 	   :class => "Array",
+	   :puppet_type => "Array",
          },
           # Test Hash
          {
            :key => "test_hash",
            :value => { "key" => "test", "value" => "test2" },
-           :retval => '{"key"=>"test", "value"=>"test2"}',
-           :nonserial_class => String,
+           :nonserial_retval => '{"key"=>"test", "value"=>"test2"}',
+           :nonserial_class => "String",
 	   :class => "Hash",
+	   :puppet_type => "Hash",
          },
       ]
 end
@@ -220,11 +226,12 @@ def providers()
 	  "url" => "mock://",
           "serialize" => true,
   },
-  {
-	  "name" => "mock with serialize true and mode is 'native'",
-	  "url" => "mock://",
-          "serialize" => true,
-  },
+  # {
+	  # "name" => "mock with serialize true and mode is 'native'",
+	  # "url" => "mock://",
+  #         "serialize" => true,
+	  # "mode" => 'native',
+  # },
   {
 	  "name" => "consul with serialize false and with daemon",
 	  "url" => "consul://172.17.0.1:8500/puppet",
@@ -239,14 +246,14 @@ def providers()
 	  "softfail" => false,
 	  "should_error" => false,
   },
-  {
-	  "name" => "consul with serialize true and mode is 'native' and with daemon",
-	  "url" => "consul://172.17.0.1:8500/puppet",
-          "serialize" => true,
-	  "mode" => 'native',
-	  "softfail" => false,
-	  "should_error" => false,
-  },
+#  {
+	  # "name" => "consul with serialize true and mode is 'native' and with daemon",
+	  # "url" => "consul://172.17.0.1:8500/puppet",
+          # "serialize" => true,
+	  # "mode" => 'native',
+	  # "softfail" => false,
+	  # "should_error" => false,
+  # },
   {
 	  "name" => "consul with ssl and without auth and with daemon",
 	  "url" => "consul+ssl+noverify://172.17.0.1:8501/puppet",


### PR DESCRIPTION
* When serialize is true, convert data into json on put/atomic_put
* When serialize is true, convert data from json on
  get/atomic_get/list/atomic_list based on the data type in <key>.meta
* Update all spec tests to support this change
* Add a sanitize_input() function that uses symbol_table() to figure out
  required parameters, and check them for sanity. This should replace
  the provider specific error checking.

SIMP-3110 #close