### PR TITLE
(SIMP-3407) Fix idempoency on acl token generation

### DIFF
--- a/files/consul/consul-create-acl
+++ b/files/consul/consul-create-acl
@@ -1,12 +1,24 @@
 #!/bin/sh
-TOKEN=$(cat $1)
-OUTPUTFILE=$2
 # Give consul some time to attempt a join, then realize it's bootstrapping
 # a new cluster
 sleep 10
+
+while getopts ":t:" o; do
+    case "${o}" in
+        t)
+            TYPE=${OPTARG}
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+TOKEN=$(cat $1)
+OUTPUTFILE=$2
+
 if [ "${TYPE}" = "" ] ; then
   TYPE="libkv"
 fi
+
 case "${TYPE}" in
 	libkv)
 		POLICY='{

--- a/manifests/consul.pp
+++ b/manifests/consul.pp
@@ -55,7 +55,7 @@ class libkv::consul(
 	],
       }
       exec { "/usr/bin/consul-create-acl -t agent_token /etc/simp/bootstrap/consul/master_token /etc/simp/bootstrap/consul/agent_token":
-        creates => "/etc/simp/bootstrap/consul/libkv_token",
+        creates => "/etc/simp/bootstrap/consul/agent_token",
         require => [
 		Service['consul'],
 		File["/usr/bin/consul-create-acl"],
@@ -182,5 +182,8 @@ class libkv::consul(
   class { '::consul':
     config_hash          => $merged_hash,
     version => $version,
+  }
+  file { "/usr/bin/consul":
+    target => "/usr/local/bin/consul",
   }
 }


### PR DESCRIPTION
* Fix consul-create-acl to use options correctly, and
  generate files in the correct location

SIMP-3407 #close