### PR TITLE
(SIMP-3429) libkv::list isn't always removing keys

### DIFF
--- a/lib/puppet_x/libkv/consul_provider.rb
+++ b/lib/puppet_x/libkv/consul_provider.rb
@@ -283,7 +283,7 @@ libkv.load("consul") do
     if (last_char != "/")
       key = key + "/"
     end
-    reg = Regexp.new("^" + @basepath.gsub(/\//, "") + key)
+    reg = Regexp.new("^" + @basepath.gsub(/^\//, "") + key)
     unless (value == nil)
       value.each do |entry|
         nkey = entry["Key"].gsub(reg,"")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -256,6 +256,13 @@ def providers()
 	  # "should_error" => false,
   # },
   {
+	  "name" => "consul with ssl and without auth and with daemon and multiple path segments",
+	  "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet/default/",
+          "serialize" => true,
+	  "softfail" => false,
+	  "should_error" => false,
+  },
+  {
 	  "name" => "consul with ssl and without auth and with daemon",
 	  "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet",
           "serialize" => true,


### PR DESCRIPTION
libkv::atomic_list was not properly stripping / from the
beginning of the path, and instead was stripping every /,
breaking the regex.

SIMP-3429 #close