### PR TITLE
(SIMP-3446) Add parameters to reocnfigure http and https listen

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,9 +5,6 @@ libkv::consul::puppet_cert_path: '/etc/puppetlabs/puppet/ssl'
 libkv::consul::config_hash:
   acl_datacenter: "dc1"
   acl_default_policy: "deny"
-  addresses:
-    http: '127.0.0.1'
-    https: '0.0.0.0'
   ports:
     https: 8501
     http: 8500

--- a/manifests/consul.pp
+++ b/manifests/consul.pp
@@ -10,6 +10,8 @@ class libkv::consul(
   $bootstrap = false,
   $dont_copy_files = false,
   $serverhost = undef,
+  $http_listen = '127.0.0.1',
+  $https_listen = '0.0.0.0',
   $advertise = undef,
   $datacenter = undef,
   $puppet_cert_path,
@@ -203,10 +205,14 @@ class libkv::consul(
   # Use softfail to get around issues if the service isn't up
   $hash = lookup('consul::config_hash', { "default_value" => {} })
   $class_hash =     {
-    'server'           => $server,
-    'node_name'        => $::hostname,
-    'retry_join'       => [ $_serverhost ],
-    'advertise_addr'   => $_advertise,
+    'server'         => $server,
+    'node_name'      => $::hostname,
+    'retry_join'     => [ $_serverhost ],
+    'advertise_addr' => $_advertise,
+    'addresses'      => {
+      'http'         => $http_listen,
+      'https'        => $https_listen,
+    },
   }
   $merged_hash = $hash + $class_hash + $_datacenter + $config_hash + $_key_hash + $_token_hash + $_bootstrap_hash + $_cert_hash
   class { '::consul':


### PR DESCRIPTION
Add libkv::consul::http_listen and libkv::consul::https_listen
to reconfigure http and https listen addresses, for scenarios
where the user will want to (ie fips and vagrant)

SIMP-3446 #close