### PR TITLE
(SIMP-3629) libkv::atomic_put returns false for a successful put on consul >0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
-  gem 'diplomat', '~> 1.1'
+  gem 'semantic_puppet'
 end
 
 group :development do

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
 	config.vm.define "consul-ssl" do |config|
 		config.vm.synced_folder ".", "/vagrant"
 		config.vm.provider "docker" do |d|
-			d.image = "consul"
+			d.image = "consul:0.9.2"
 			d.has_ssh = false
 			d.env = {
 				"CONSUL_LOCAL_CONFIG" => '{
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
 	config.vm.define "consul-ssl-auth" do |config|
 		config.vm.synced_folder ".", "/vagrant"
 		config.vm.provider "docker" do |d|
-			d.image = "consul"
+			d.image = "consul:0.9.2"
 			d.has_ssh = false
 			d.env = {
 				"CONSUL_LOCAL_CONFIG" => '{

--- a/bootstrap/consul.pp
+++ b/bootstrap/consul.pp
@@ -15,13 +15,13 @@ exec { "/opt/puppetlabs/bin/puppet cert generate server.dc1.consul":
 	creates => '/etc/puppetlabs/puppet/ssl/private_keys/server.dc1.consul.pem',
 } ->
 file { "/etc/simp/bootstrap/consul/server.dc1.consul.private.pem":
-source => '/etc/puppetlabs/puppet/ssl/private_keys/server.dc1.consul.pem',
+  source => '/etc/puppetlabs/puppet/ssl/private_keys/server.dc1.consul.pem',
 } ->
 file { "/etc/simp/bootstrap/consul/server.dc1.consul.cert.pem":
-source => '/etc/puppetlabs/puppet/ssl/certs/server.dc1.consul.pem',
+  source => '/etc/puppetlabs/puppet/ssl/certs/server.dc1.consul.pem',
 } ->
 file { "/etc/simp/bootstrap/consul/ca.pem":
-source => '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem',
+  source => '/etc/puppetlabs/puppet/ssl/ca/ca_crt.pem',
 } -> 
 class { "libkv::consul":
 	dont_copy_files => true,

--- a/lib/puppet_x/libkv/consul_provider.rb
+++ b/lib/puppet_x/libkv/consul_provider.rb
@@ -201,9 +201,10 @@ libkv.load("consul") do
       throw Exception
     end
     previndex=previous["ModifyIndex"]
-    response = consul_request(path: "/v1/kv" + @basepath + key + "?cas=" + previndex.to_s, method: 'PUT', body: value)
+    path = "/v1/kv" + @basepath + key + "?cas=" + previndex.to_s
+    response = consul_request(path: path, method: 'PUT', body: value)
     if (response.class == Net::HTTPOK)
-      if (response.body == "true\n")
+      if (response.body =~ /true/)
         true
       else
         false
@@ -227,7 +228,7 @@ libkv.load("consul") do
     previndex=previous["ModifyIndex"]
     response = consul_request(path: "/v1/kv" + @basepath + key + "?cas=" + previndex.to_s, method: 'DELETE')
     if (response.class == Net::HTTPOK)
-      if (response.body == "true\n")
+      if (response.body =~ /true/)
         true
       else
         false
@@ -244,7 +245,7 @@ libkv.load("consul") do
     # Get the value of key first. This is the only way to tell if we try to delete a key 
     response = consul_request(path: "/v1/kv" + @basepath + key, method: 'DELETE')
     if (response.class == Net::HTTPOK)
-      if (response.body == "true\n")
+      if (response.body =~ /true/)
         true
       else
         false

--- a/spec/functions/libkv_atomic_put_spec.rb
+++ b/spec/functions/libkv_atomic_put_spec.rb
@@ -81,6 +81,20 @@ describe 'libkv::atomic_put' do
        else
          expected_retval = hash[:nonserial_retval]
        end
+       it "should return true of type #{klass} for /atomic_put/#{hash[:key]} when previous is correct" do
+         params = {
+             'key' => "/atomic_put/" + hash[:key],
+         }.merge(shared_params)
+         original = call_function("libkv::atomic_get", params)
+
+         params = {
+             'key' => "/atomic_put/" + hash[:key],
+             'value' => hash[:value],
+             'previous' => original,
+         }.merge(shared_params)
+         result = subject.execute(params)
+         expect(result.to_s).to eql("true")
+       end
         it "should return an object of type #{klass} for /atomic_put/#{hash[:key]}" do
           params = {
              'key' => "/atomic_put/" + hash[:key],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,11 +3,13 @@ require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts
 
+require 'semantic_puppet'
+
 require 'pathname'
 
 # RSpec Material
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
+module_name = File.basename(File.expand_path(File.join(__FILE__, '../..')))
 
 # Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
 if Puppet.version < "4.0.0"
@@ -17,7 +19,7 @@ if Puppet.version < "4.0.0"
 end
 
 
-if !ENV.key?( 'TRUSTED_NODE_DATA' )
+if !ENV.key?('TRUSTED_NODE_DATA')
   warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
   ENV['TRUSTED_NODE_DATA']='yes'
 end
@@ -47,7 +49,7 @@ EOM
 # end
 #
 def set_environment(environment = :production)
-    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+  RSpec.configure {|c| c.default_facts['environment'] = environment.to_s}
 end
 
 # This can be used from inside your spec tests to load custom hieradata within
@@ -69,25 +71,25 @@ end
 #
 # Note: Any colons (:) are replaced with underscores (_) in the class name.
 def set_hieradata(hieradata)
-    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+  RSpec.configure {|c| c.default_facts['custom_hiera'] = hieradata}
 end
 
-if not File.directory?(File.join(fixture_path,'hieradata')) then
-  FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
+if not File.directory?(File.join(fixture_path, 'hieradata')) then
+  FileUtils.mkdir_p(File.join(fixture_path, 'hieradata'))
 end
 
-if not File.directory?(File.join(fixture_path,'modules',module_name)) then
-  FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
+if not File.directory?(File.join(fixture_path, 'modules', module_name)) then
+  FileUtils.mkdir_p(File.join(fixture_path, 'modules', module_name))
 end
 
 RSpec.configure do |c|
   # If nothing else...
   c.default_facts = {
-    :production => {
-      #:fqdn           => 'production.rspec.test.localdomain',
-      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
-    }
+      :production => {
+          #:fqdn           => 'production.rspec.test.localdomain',
+          :path => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+          :concat_basedir => '/tmp'
+      }
   }
 
   c.mock_framework = :rspec
@@ -96,12 +98,12 @@ RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
 
-  c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
+  c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 
   # Useless backtrace noise
   backtrace_exclusion_patterns = [
-    /spec_helper/,
-    /gems/
+      /spec_helper/,
+      /gems/
   ]
 
   if c.respond_to?(:backtrace_exclusion_patterns)
@@ -124,7 +126,7 @@ RSpec.configure do |c|
 
     if defined?(environment)
       set_environment(environment)
-      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp, environment.to_s))
     end
 
     # ensure the user running these tests has an accessible environmentpath
@@ -134,9 +136,9 @@ RSpec.configure do |c|
 
     # sanitize hieradata
     if defined?(hieradata)
-      set_hieradata(hieradata.gsub(':','_'))
+      set_hieradata(hieradata.gsub(':', '_'))
     elsif defined?(class_name)
-      set_hieradata(class_name.gsub(':','_'))
+      set_hieradata(class_name.gsub(':', '_'))
     end
     `curl -sX DELETE http://172.17.0.1:10500/v1/kv/puppet?recurse`
     `curl -sX DELETE http://172.17.0.1:10504/v1/kv/puppet?recurse`
@@ -156,153 +158,175 @@ Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
     fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
   end
 end
+
 def datatype_testspec
-  [
-          # Test String
-         {
+
+  rubyver = SemanticPuppet::Version.parse(RUBY_VERSION);
+  requiredver = SemanticPuppet::Version.parse("2.4.0");
+  if (rubyver >= requiredver)
+    integer = [
+    # Test Number
+    {
+      :key => "test_number",
+      :value => 255,
+      :nonserial_retval => '255',
+      :nonserial_class => "String",
+      :class => "Integer",
+      :puppet_type => "Integer",
+    }
+    ]
+  else
+    integer = [
+        # Test Number
+        {
+            :key => "test_number",
+            :value => 255,
+            :nonserial_retval => '255',
+            :nonserial_class => "String",
+            :class => "Fixnum",
+            :puppet_type => "Integer",
+        }
+    ]
+  end
+
+  integer + [
+      # Test String
+     {
           :key => "test_string",
-           :value => "test1",
-           :nonserial_retval => "test1",
-           :nonserial_class => "String",
-	   :class => "String",
-	   :puppet_type => "String",
-         },
-          # Test Boolean
-         {
-           :key => "test_boolean",
-           :value => true,
-           :nonserial_retval => "true",
-           :nonserial_class => "String",
-	   :class => "TrueClass",
-	   :puppet_type => "Boolean",
-         },
-          # Test Number
-         {
-           :key => "test_number",
-           :value => 255,
-           :nonserial_retval => '255',
-           :nonserial_class => "String",
-	   :class => "Fixnum",
-	   :puppet_type => "Integer",
-         },
-          # Test Float
-         {
-           :key => "test_float",
-           :value => 2.38490,
-           :nonserial_retval => '2.3849',
-           :nonserial_class => "String",
-	   :class => "Float",
-	   :puppet_type => "Float",
-         },
-          # Test Array
-         {
-           :key => "test_array",
-           :value => [ "test3", "test4"],
-           :nonserial_retval => '["test3", "test4"]',
-           :nonserial_class => "String",
-	   :class => "Array",
-	   :puppet_type => "Array",
-         },
-          # Test Hash
-         {
-           :key => "test_hash",
-           :value => { "key" => "test", "value" => "test2" },
-           :nonserial_retval => '{"key"=>"test", "value"=>"test2"}',
-           :nonserial_class => "String",
-	   :class => "Hash",
-	   :puppet_type => "Hash",
-         },
-      ]
+          :value => "test1",
+          :nonserial_retval => "test1",
+          :nonserial_class => "String",
+          :class => "String",
+          :puppet_type => "String",
+      },
+      # Test Boolean
+      {
+          :key => "test_boolean",
+          :value => true,
+          :nonserial_retval => "true",
+          :nonserial_class => "String",
+          :class => "TrueClass",
+          :puppet_type => "Boolean",
+      },
+      # Test Float
+      {
+          :key => "test_float",
+          :value => 2.38490,
+          :nonserial_retval => '2.3849',
+          :nonserial_class => "String",
+          :class => "Float",
+          :puppet_type => "Float",
+      },
+      # Test Array
+      {
+          :key => "test_array",
+          :value => ["test3", "test4"],
+          :nonserial_retval => '["test3", "test4"]',
+          :nonserial_class => "String",
+          :class => "Array",
+          :puppet_type => "Array",
+      },
+      # Test Hash
+      {
+          :key => "test_hash",
+          :value => {"key" => "test", "value" => "test2"},
+          :nonserial_retval => '{"key"=>"test", "value"=>"test2"}',
+          :nonserial_class => "String",
+          :class => "Hash",
+          :puppet_type => "Hash",
+      },
+  ]
 end
+
 def providers()
-	path=File.dirname(File.dirname(__FILE__))
-[
-  {
-	  "name" => "mock with serialize false",
-	  "url" => "mock://",
+  path=File.dirname(File.dirname(__FILE__))
+  [
+      {
+          "name" => "mock with serialize false",
+          "url" => "mock://",
           "serialize" => false,
-  },
-  {
-	  "name" => "mock with serialize true and mode is unset",
-	  "url" => "mock://",
+      },
+      {
+          "name" => "mock with serialize true and mode is unset",
+          "url" => "mock://",
           "serialize" => true,
-  },
-  # {
-	  # "name" => "mock with serialize true and mode is 'native'",
-	  # "url" => "mock://",
-  #         "serialize" => true,
-	  # "mode" => 'native',
-  # },
-  {
-	  "name" => "consul with serialize false and with daemon",
-	  "url" => "consul://172.17.0.1:10500/puppet",
+      },
+      # {
+      # "name" => "mock with serialize true and mode is 'native'",
+      # "url" => "mock://",
+      #         "serialize" => true,
+      # "mode" => 'native',
+      # },
+      {
+          "name" => "consul with serialize false and with daemon",
+          "url" => "consul://172.17.0.1:10500/puppet",
           "serialize" => false,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
-  {
-	  "name" => "consul with serialize true and mode is unset and with daemon",
-	  "url" => "consul://172.17.0.1:10500/puppet",
+          "softfail" => false,
+          "should_error" => false,
+      },
+      {
+          "name" => "consul with serialize true and mode is unset and with daemon",
+          "url" => "consul://172.17.0.1:10500/puppet",
           "serialize" => true,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
-#  {
-	  # "name" => "consul with serialize true and mode is 'native' and with daemon",
-	  # "url" => "consul://172.17.0.1:8500/puppet",
-          # "serialize" => true,
-	  # "mode" => 'native',
-	  # "softfail" => false,
-	  # "should_error" => false,
-  # },
-  {
-	  "name" => "consul with ssl and without auth and with daemon and multiple path segments",
-	  "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet/default/",
+          "softfail" => false,
+          "should_error" => false,
+      },
+      #  {
+      # "name" => "consul with serialize true and mode is 'native' and with daemon",
+      # "url" => "consul://172.17.0.1:8500/puppet",
+      # "serialize" => true,
+      # "mode" => 'native',
+      # "softfail" => false,
+      # "should_error" => false,
+      # },
+      {
+          "name" => "consul with ssl and without auth and with daemon and multiple path segments",
+          "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet/default/",
           "serialize" => true,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
-  {
-	  "name" => "consul with ssl and without auth and with daemon",
-	  "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet",
+          "softfail" => false,
+          "should_error" => false,
+      },
+      {
+          "name" => "consul with ssl and without auth and with daemon",
+          "url" => "consul+ssl+noverify://172.17.0.1:10501/puppet",
           "serialize" => true,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
-  {
-	  "name" => "consul with ssl and with server verification and with daemon",
-	  "url" => "consul+ssl+verify://172.17.0.1:10501/puppet",
+          "softfail" => false,
+          "should_error" => false,
+      },
+      {
+          "name" => "consul with ssl and with server verification and with daemon",
+          "url" => "consul+ssl+verify://172.17.0.1:10501/puppet",
           "auth" => {
               "ca_file" => "#{path}/test/ca.crt",
           },
           "serialize" => true,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
-  {
-	  "name" => "consul with ssl and with server verification and certificate auth and with daemon",
-	  "url" => "consul+ssl+verify://172.17.0.1:10503/puppet",
+          "softfail" => false,
+          "should_error" => false,
+      },
+      {
+          "name" => "consul with ssl and with server verification and certificate auth and with daemon",
+          "url" => "consul+ssl+verify://172.17.0.1:10503/puppet",
           "auth" => {
               "ca_file" => "#{path}/test/ca.crt",
-	      "cert_file" => "#{path}/test/server.crt",
-	      "key_file" => "#{path}/test/server.key",
+              "cert_file" => "#{path}/test/server.crt",
+              "key_file" => "#{path}/test/server.key",
           },
           "serialize" => true,
-	  "softfail" => false,
-	  "should_error" => false,
-  },
+          "softfail" => false,
+          "should_error" => false,
+      },
   # {
-	  # "name" => "consul without daemon and softfail = false",
-	  # "url" => "consul://172.17.0.1:8500/puppet",
-	  # "softfail" => false,
+  # "name" => "consul without daemon and softfail = false",
+  # "url" => "consul://172.17.0.1:8500/puppet",
+  # "softfail" => false,
   #         "should_error" => true,
   # },
   # {
-	  # "name" => "consul without daemon and softfail = true",
-	  # "url" => "consul://172.17.0.1:8500/puppet",
-	  # "softfail" => false,
+  # "name" => "consul without daemon and softfail = true",
+  # "url" => "consul://172.17.0.1:8500/puppet",
+  # "softfail" => false,
   #         "should_error" => false,
   # },
-]
+  ]
 end
 


### PR DESCRIPTION
The consul provider was checking explicitly that the output of atomic_put was 'true\n'. Replaced with a regex to check with or without a newline

SIMP-3629 #close